### PR TITLE
Allow running admixture analysis with multiple K in one run

### DIFF
--- a/admixture.py
+++ b/admixture.py
@@ -156,14 +156,14 @@ def alphaSearch(aEnd, depth, indF, K, likeMatrix, iter, tole, seed, batch, t):
 	Q_best, F_best, L_best = admixNMF(indF, K, likeMatrix, aMin, iter, tole, seed, batch, t)
 	argL = 0
 	aBest = aMin
-	
+
 	print "\n" + "NMF: K=" + str(K) + ", alpha=" + str(aMid) + ", batch=" + str(batch) + " and seed=" + str(seed)
 	Q_test, F_test, L_test = admixNMF(indF, K, likeMatrix, aMid, iter, tole, seed, batch, t)
 	if L_test > L_best:
 		Q_best, F_best, L_best = np.copy(Q_test), np.copy(F_test), L_test
 		argL = 1
 		aBest = aMid
-	
+
 	print "\n" + "NMF: K=" + str(K) + ", alpha=" + str(aMax) + ", batch=" + str(batch) + " and seed=" + str(seed)
 	Q_test, F_test, L_test = admixNMF(indF, K, likeMatrix, aMax, iter, tole, seed, batch, t)
 	if L_test > L_best:

--- a/admixture.py
+++ b/admixture.py
@@ -60,7 +60,7 @@ def updateQ(Q, A, QB, alpha):
 			Q[i, k] = min(Q[i, k], 1-(1e-4))
 
 # Estimate admixture using non-negative matrix factorization
-def admixNMF(X, K, likeMatrix, alpha=0, iter=100, tole=5e-5, seed=0, batch=5, threads=1):
+def admixNMF(X, K, likeMatrix, alpha=0, iter=100, tole=5e-5, seed=None, batch=5, threads=1):
 	m, n = X.shape # Dimensions of individual allele frequencies
 
 	# Shuffle individual allele frequencies

--- a/pcangsd.py
+++ b/pcangsd.py
@@ -357,7 +357,7 @@ if args.admix:
 	if len(args.admix_K) < 1:
 		K_list = [nEV + 1, ]
 	else:
-		K_list = args.K_list
+		K_list = args.admix_K
 
 	S_list = args.admix_seed
 

--- a/pcangsd.py
+++ b/pcangsd.py
@@ -359,11 +359,7 @@ if args.admix:
 	else:
 		K_list = args.K_list
 
-	if args.admix_seed[0] == None:
-		from time import time
-		S_list = [int(time())]
-	else:
-		S_list = args.admix_seed
+	S_list = args.admix_seed
 
 	for K in K_list:
 		# Automatic search for optimal alpha parameter

--- a/pcangsd.py
+++ b/pcangsd.py
@@ -76,7 +76,7 @@ parser.add_argument("-admix_alpha", metavar="FLOAT-LIST", type=float, nargs="+",
 	help="Sparseness parameter for NMF in estimation of admixture proportions")
 parser.add_argument("-admix_seed", metavar="INT-LIST", type=int, nargs="+", default=[None],
 	help="Random seed for admixture estimation")
-parser.add_argument("-admix_K", metavar="INT", type=int,
+parser.add_argument("-admix_K", metavar="INT-LIST", type=int, nargs="+", default=[],
 	help="Number of ancestral population for admixture estimation")
 parser.add_argument("-admix_iter", metavar="INT", type=int, default=50,
 	help="Maximum iterations for admixture estimation - NMF (50)")
@@ -354,10 +354,10 @@ elif args.genoInbreed != None:
 
 ##### Admixture proportions #####
 if args.admix:
-	if args.admix_K != None:
-		K = args.admix_K
+	if len(args.admix_K) < 1:
+		K_list = [nEV + 1, ]
 	else:
-		K = nEV + 1
+		K_list = args.K_list
 
 	if args.admix_seed[0] == None:
 		from time import time
@@ -365,44 +365,45 @@ if args.admix:
 	else:
 		S_list = args.admix_seed
 
-	# Automatic search for optimal alpha parameter
-	if args.admix_auto != None:
-		print "\n" + ""
-		Q_admix, F_admix, a_best = alphaSearch(args.admix_auto, args.admix_depth, indf, K, likeMatrix, args.admix_iter, args.admix_tole, S_list[0], args.admix_batch, args.threads)
-		pd.DataFrame(Q_admix).to_csv(str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".qopt", sep=" ", header=False, index=False)
-		print "Saved admixture proportions as " + str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".qopt"
+	for K in K_list:
+		# Automatic search for optimal alpha parameter
+		if args.admix_auto != None:
+			print "\n" + ""
+			Q_admix, F_admix, a_best = alphaSearch(args.admix_auto, args.admix_depth, indf, K, likeMatrix, args.admix_iter, args.admix_tole, S_list[0], args.admix_batch, args.threads)
+			pd.DataFrame(Q_admix).to_csv(str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".qopt", sep=" ", header=False, index=False)
+			print "Saved admixture proportions as " + str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".qopt"
 
-		if args.admix_save:
-			if args.admix_seed[0] == None:
-				np.save(str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".fopt", F_admix)
-				print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".fopt.npy (Binary)"
-
-	# Standard admixture estimation
-	else:
-		for a in args.admix_alpha:
-			for s in S_list:
-				print "\n" + "Estimating admixture using NMF with K=" + str(K) + ", alpha=" + str(a) + ", batch=" + str(args.admix_batch) + " and seed=" + str(s)
-				Q_admix, F_admix, _ = admixNMF(indf, K, likeMatrix, a, args.admix_iter, args.admix_tole, s, args.admix_batch, args.threads)
-
-				# Save data frame
+			if args.admix_save:
 				if args.admix_seed[0] == None:
-					pd.DataFrame(Q_admix).to_csv(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".qopt", sep=" ", header=False, index=False)
-					print "Saved admixture proportions as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".qopt"
-				else:
-					pd.DataFrame(Q_admix).to_csv(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".qopt", sep=" ", header=False, index=False)
-					print "Saved admixture proportions as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".qopt"
+					np.save(str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".fopt", F_admix)
+					print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".fopt.npy (Binary)"
 
-				if args.admix_save:
+		# Standard admixture estimation
+		else:
+			for a in args.admix_alpha:
+				for s in S_list:
+					print "\n" + "Estimating admixture using NMF with K=" + str(K) + ", alpha=" + str(a) + ", batch=" + str(args.admix_batch) + " and seed=" + str(s)
+					Q_admix, F_admix, _ = admixNMF(indf, K, likeMatrix, a, args.admix_iter, args.admix_tole, s, args.admix_batch, args.threads)
+
+					# Save data frame
 					if args.admix_seed[0] == None:
-						np.save(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".fopt", F_admix)
-						print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".fopt.npy (Binary)"
+						pd.DataFrame(Q_admix).to_csv(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".qopt", sep=" ", header=False, index=False)
+						print "Saved admixture proportions as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".qopt"
 					else:
-						np.save(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".fopt", F_admix)
-						print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".fopt.npy (Binary)"
+						pd.DataFrame(Q_admix).to_csv(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".qopt", sep=" ", header=False, index=False)
+						print "Saved admixture proportions as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".qopt"
 
-				# Release memory
-				del Q_admix
-				del F_admix
+					if args.admix_save:
+						if args.admix_seed[0] == None:
+							np.save(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".fopt", F_admix)
+							print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".fopt.npy (Binary)"
+						else:
+							np.save(str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".fopt", F_admix)
+							print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a) + ".s" + str(s) + ".fopt.npy (Binary)"
+
+					# Release memory
+					del Q_admix
+					del F_admix
 
 
 ##### Optional saves #####

--- a/pcangsd.py
+++ b/pcangsd.py
@@ -377,7 +377,8 @@ if args.admix:
 				if args.admix_seed[0] == None:
 					np.save(str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".fopt", F_admix)
 					print "Saved population-specific allele frequencies as " + str(args.o) + ".K" + str(K) + ".a" + str(a_best) + ".fopt.npy (Binary)"
-
+			del Q_admix
+			del F_admix
 		# Standard admixture estimation
 		else:
 			for a in args.admix_alpha:


### PR DESCRIPTION
Hi Jonas,

This simple patch-set basically wraps the admixture-related code in a for loop over K, and allows `-admix_K` to accept multiple arguments (as a *space*-separated list). Reading the wiki, I thought PCAngsd could do this already, but the current code didn't allow it.

I've also (accidentally) included a change I made which seeds the random seed generator with `None` rather than the current time if no seed is provided, which will use `/dev/urandom` where available, to avoid two concurrent PCAngsds having the same seed. In retrospect this is probably a non-problem,  but the change also does no harm I can forsee, so I've left the change in for now.

Also, vim removed a bunch of trailing whitespace. It may be easier to view the changes if you add ` ?w=1` to the URL to ignore whitespace.

Cheers,
Kevin
