### PR TITLE
Option to write out genotype posteriors given the individual allele freqs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
     - numpy
     - scipy
     - cython
+    - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,3 @@ dependencies:
     - numpy
     - scipy
     - cython
-    - pandas

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -404,46 +404,6 @@ def main():
 				".gpost.tsv\n")
 		del G
 
-	### Admixture estimation ###
-	if args.admix:
-		print("Estimating admixture proportions using NMF (CSG-MU).")
-		if args.admix_K is not None:
-			a_K = args.admix_K
-		else:
-			a_K = K + 1
-		if args.admix_auto is None:
-			print("K=" + str(a_K) + ", Alpha=" + str(args.admix_alpha) + \
-					", Batches=" + str(args.admix_batch) + ", Seed=" + str(args.admix_seed))
-			Q, F, _ = admixture.admixNMF(L, P, a_K, args.admix_alpha, args.admix_iter, \
-											args.admix_tole, args.admix_batch, \
-											args.admix_seed, True, args.threads)
-
-			# Save factor matrices
-			np.savetxt(args.out + ".admix." + str(a_K) + ".Q", Q, fmt="%.7f")
-			print("Saved admixture proportions as " + str(args.out) + ".admix." + \
-					str(a_K) + ".Q (Text)")
-			np.save(args.out + ".admix." + str(a_K) + ".F", F.astype(float))
-			print("Saved ancestral allele frequencies proportions as " + \
-					str(args.out) + ".admix." + str(a_K) + ".F.npy (Binary)\n")
-		else:
-			print("Automatic search for best alpha with depth=" + str(args.admix_depth))
-			print("K=" + str(a_K) + ", Batches=" + \
-					str(args.admix_batch) + ", Seed=" + str(args.admix_seed))
-			Q, F, lB, aB = admixture.alphaSearch(L, P, a_K, args.admix_auto, \
-												args.admix_iter, args.admix_tole, \
-												args.admix_batch, args.admix_seed, \
-												args.admix_depth, args.threads)
-			print("Search concluded: Alpha=" + str(aB) + ", log-likelihood" + str(lB))
-
-			# Save factor matrices
-			np.savetxt(args.out + ".admix." + str(a_K) + ".Q", Q, fmt="%.7f")
-			print("Saved admixture proportions as " + str(args.out) + ".admix." + \
-					str(a_K) + ".Q (Text)")
-			np.save(args.out + ".admix." + str(a_K) + ".F", F.astype(float))
-			print("Saved ancestral allele frequencies proportions as " + \
-					str(args.out) + ".admix." + str(a_K) + ".F.npy (Binary)\n")
-		del Q, F
-
 
 	### Tree estimation ###
 	if args.tree:

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -12,7 +12,6 @@ import argparse
 import os
 import subprocess
 import sys
-import pandas as pd
 from datetime import datetime
 
 # Find length of PLINK files

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -348,13 +348,15 @@ def main():
 
 	### Genotype Posterior calculation and write out
 	if args.post_save:
-		print("Calculating and writing genotype posteriors from individual allele freqs")
+		print("Calculating genotype posteriors from individual allele freqs")
 		G = shared.calcPost(L, P, None, args.threads)
-
+		#print("Converting posteriors to pandas object")
 		# Write out genotype posteriors matrix
-		df = pd.DataFrame(G)  # make a pandas data frame out of it
-		df.to_csv(args.out + ".gpost.tsv.gz", sep="\t", compression="gzip",\
-				header = False, index = False, float_format = "%.3e")
+		#df = pd.DataFrame(G)  # make a pandas data frame out of it
+		print("Writing posteriors to tsv file")
+		#df.to_csv(args.out + ".gpost.tsv.gz", sep="\t", compression="gzip", chunksize=1000000,\
+		#		header = False, index = False, float_format = "%.3e")
+		np.savetxt(fname=args.out + ".gpost.tsv.gz", X=G, fmt="%1.4e", delimiter="\t")
 		print("Saved genotype posteriors as " + str(args.out) + \
 				".gpost.tsv.gz\n")
 		del G

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -12,6 +12,7 @@ import argparse
 import os
 import subprocess
 import sys
+import pandas as pd
 from datetime import datetime
 
 # Find length of PLINK files
@@ -73,6 +74,8 @@ parser.add_argument("--geno", metavar="FLOAT", type=float,
 	help="Call genotypes from posterior probabilities with threshold")
 parser.add_argument("--genoInbreed", metavar="FLOAT", type=float,
 	help="Call genotypes (inbreeding) from posterior probabilities with threshold")
+parser.add_argument("--post_save", action="store_true",
+	help="Write genotype posteriors (from individual allele freqs) to TSV file")
 parser.add_argument("--admix", action="store_true",
 	help="Estimate admixture proportions and ancestral allele frequencies")
 parser.add_argument("--admix_K", metavar="INT", type=int,
@@ -342,6 +345,19 @@ def main():
 		print("Saved called genotype matrix as " + str(args.out) + \
 				".geno.inbreed.npy (Binary - np.int8)\n")
 		del G, F
+
+	### Genotype Posterior calculation and write out
+	if args.post_save is not None:
+		print("Calculating and writing genotype posteriors from individual allele freqs"
+		G = shared.callGeno(L, P, None, args.threads)
+
+		# Write out genotype posteriors matrix
+		df = pd.DataFrame(G)  # make a pandas data frame out of it
+		df.to_csv(args.out + ".gpost.tsv.gz", sep="\t", compression="gzip",\
+				header = False, index = False)
+		print("Saved genotype posteriors as " + str(args.out) + \
+				".gpost.tsv.gz\n")
+		del G
 
 	### Admixture estimation ###
 	if args.admix:

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -96,7 +96,7 @@ parser.add_argument("--dosage_save", action="store_true",
 	help="Save genotype dosages")
 parser.add_argument("--sites_save", action="store_true",
 	help="Save boolean vector of used sites")
-parser.add_argument("--geno_posterior_save", action="store_true",
+parser.add_argument("--geno_post_save", action="store_true",
 	help="Write genotype posteriors, using indiv allele freqs as prior, to .gpost.tsv")
 
 
@@ -395,7 +395,7 @@ def main():
 		del G, F
 
 	### Genotype Posterior calculation and write out
-	if args.geno_posterior_save:
+	if args.geno_post_save:
 		print("Calculating genotype posteriors from individual allele freqs")
 		G = shared.calcPost(L, P, None, args.threads)
 		print("Writing posteriors to tsv file")

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -347,14 +347,14 @@ def main():
 		del G, F
 
 	### Genotype Posterior calculation and write out
-	if args.post_save is not None:
-		print("Calculating and writing genotype posteriors from individual allele freqs"
-		G = shared.callGeno(L, P, None, args.threads)
+	if args.post_save:
+		print("Calculating and writing genotype posteriors from individual allele freqs")
+		G = shared.calcPost(L, P, None, args.threads)
 
 		# Write out genotype posteriors matrix
 		df = pd.DataFrame(G)  # make a pandas data frame out of it
 		df.to_csv(args.out + ".gpost.tsv.gz", sep="\t", compression="gzip",\
-				header = False, index = False)
+				header = False, index = False, float_format = "%.3e")
 		print("Saved genotype posteriors as " + str(args.out) + \
 				".gpost.tsv.gz\n")
 		del G

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -66,8 +66,6 @@ parser.add_argument("--geno", metavar="FLOAT", type=float,
 	help="Call genotypes from posterior probabilities with threshold")
 parser.add_argument("--geno_inbreed", metavar="FLOAT", type=float,
 	help="Call genotypes (inbreeding) from posterior probabilities with threshold")
-parser.add_argument("--post_save", action="store_true",
-	help="Write genotype posteriors (from individual allele freqs) to TSV file")
 parser.add_argument("--admix", action="store_true",
 	help="Estimate admixture proportions and ancestral allele frequencies")
 parser.add_argument("--admix_K", metavar="INT", type=int,
@@ -98,6 +96,8 @@ parser.add_argument("--dosage_save", action="store_true",
 	help="Save genotype dosages")
 parser.add_argument("--sites_save", action="store_true",
 	help="Save boolean vector of used sites")
+parser.add_argument("--geno_posterior_save", action="store_true",
+	help="Write genotype posteriors, using indiv allele freqs as prior, to .gpost.tsv")
 
 
 ##### PCAngsd #####
@@ -395,7 +395,7 @@ def main():
 		del G, F
 
 	### Genotype Posterior calculation and write out
-	if args.post_save:
+	if args.geno_posterior_save:
 		print("Calculating genotype posteriors from individual allele freqs")
 		G = shared.calcPost(L, P, None, args.threads)
 		print("Writing posteriors to tsv file")

--- a/pcangsd/pcangsd.py
+++ b/pcangsd/pcangsd.py
@@ -350,15 +350,10 @@ def main():
 	if args.post_save:
 		print("Calculating genotype posteriors from individual allele freqs")
 		G = shared.calcPost(L, P, None, args.threads)
-		#print("Converting posteriors to pandas object")
-		# Write out genotype posteriors matrix
-		#df = pd.DataFrame(G)  # make a pandas data frame out of it
 		print("Writing posteriors to tsv file")
-		#df.to_csv(args.out + ".gpost.tsv.gz", sep="\t", compression="gzip", chunksize=1000000,\
-		#		header = False, index = False, float_format = "%.3e")
-		np.savetxt(fname=args.out + ".gpost.tsv.gz", X=G, fmt="%1.4e", delimiter="\t")
+		reader_cy.writeBeagle(G, args.out + ".gpost.tsv")
 		print("Saved genotype posteriors as " + str(args.out) + \
-				".gpost.tsv.gz\n")
+				".gpost.tsv\n")
 		del G
 
 	### Admixture estimation ###

--- a/pcangsd/reader_cy.pyx
+++ b/pcangsd/reader_cy.pyx
@@ -255,22 +255,22 @@ cpdef void filterArrays(float[:,::1] L, double[::1] f, unsigned char[::1] mask) 
 # A little C-ish function here
 # for writing out the genotype posteriors (Eric A.)
 cpdef void writeBeagle(float[:,::1] Po, str beagle):
-    cdef int m = Po.shape[0]
-    cdef int n3 = Po.shape[1]
-    cdef int c = 0
-    cdef int i, s
-    #cdef FILE *outf
-    cdef FILE *pipe
+	cdef int m = Po.shape[0]
+	cdef int n3 = Po.shape[1]
+	cdef int c = 0
+	cdef int i, s
+	#cdef FILE *outf
+	cdef FILE *pipe
 
-    #pipe = popen(str.encode("gzip - > " + beagle), "wb");
-    outf = fopen(str.encode(beagle), "wb")
-    for s in range(m):
-        for i in range(n3):
-            if i == 0:
-                fprintf(outf, "%1.4e", Po[s, i])
-            else:
-                fprintf(outf, "\t%1.4e", Po[s, i])
-            if i == n3-1:
-                fprintf(outf, "\n")
-    fclose(outf)
+	#pipe = popen(str.encode("gzip - > " + beagle), "wb");
+	outf = fopen(str.encode(beagle), "wb")
+	for s in range(m):
+		for i in range(n3):
+			if i == 0:
+				fprintf(outf, "%1.4e", Po[s, i])
+			else:
+				fprintf(outf, "\t%1.4e", Po[s, i])
+			if i == n3-1:
+				fprintf(outf, "\n")
+	fclose(outf)
 

--- a/pcangsd/reader_cy.pyx
+++ b/pcangsd/reader_cy.pyx
@@ -236,10 +236,24 @@ cpdef void convertBed(float[:,::1] L, unsigned char[:,::1] G, int G_len, float e
 					break
 
 # Array filtering
+cpdef void filterArrays(float[:,::1] L, double[::1] f, unsigned char[::1] mask) \
+		noexcept nogil:
+	cdef:
+		int m = L.shape[0]
+		int n = L.shape[1]
+		int c = 0
+		int i, j
+	for j in range(m):
+		if mask[j] == 1:
+			for i in range(n):
+				L[c,i] = L[j,i] # Genotype likelihoods
+			f[c] = f[j] # Allele frequency
+			c += 1
 
 
-# Eric is going to try to put a little C-ish function here
-# for writing out the genotype posteriors
+
+# A little C-ish function here
+# for writing out the genotype posteriors (Eric A.)
 cpdef void writeBeagle(float[:,::1] Po, str beagle):
     cdef int m = Po.shape[0]
     cdef int n3 = Po.shape[1]
@@ -259,19 +273,4 @@ cpdef void writeBeagle(float[:,::1] Po, str beagle):
             if i == n3-1:
                 fprintf(outf, "\n")
     fclose(outf)
-
-
-cpdef void filterArrays(float[:,::1] L, double[::1] f, unsigned char[::1] mask) \
-		noexcept nogil:
-	cdef:
-		int m = L.shape[0]
-		int n = L.shape[1]
-		int c = 0
-		int i, j
-	for j in range(m):
-		if mask[j] == 1:
-			for i in range(n):
-				L[c,i] = L[j,i] # Genotype likelihoods
-			f[c] = f[j] # Allele frequency
-			c += 1
 

--- a/pcangsd/reader_cy.pyx
+++ b/pcangsd/reader_cy.pyx
@@ -4,7 +4,6 @@ import numpy as np
 cimport numpy as np
 from cython.parallel import prange
 from libcpp.vector cimport vector
-#from libcpp.iostrem cimport cout scientific
 from libc.string cimport strtok, strdup
 from libc.stdlib cimport atof
 from libc.stdio cimport FILE, fclose, fopen, fprintf
@@ -254,6 +253,10 @@ cpdef void filterArrays(float[:,::1] L, double[::1] f, unsigned char[::1] mask) 
 
 # A little C-ish function here
 # for writing out the genotype posteriors (Eric A.)
+# It doesn't write a proper Beagle file, as it has no headers or
+# marker/position or allele information, but it does print out tab separated
+# genotype quantities (three columns to an individual) in the individual input
+# order of the kept sites in Po.
 cpdef void writeBeagle(float[:,::1] Po, str beagle):
 	cdef int m = Po.shape[0]
 	cdef int n3 = Po.shape[1]

--- a/pcangsd/reader_cy.pyx
+++ b/pcangsd/reader_cy.pyx
@@ -5,8 +5,10 @@ cimport numpy as np
 from cython import boundscheck, wraparound
 from cython.parallel import prange
 from libcpp.vector cimport vector
+#from libcpp.iostrem cimport cout scientific
 from libc.string cimport strtok, strdup
 from libc.stdlib cimport atof
+from libc.stdio cimport FILE, fclose, fopen, fprintf
 
 DTYPE = np.float32
 ctypedef np.float32_t DTYPE_t
@@ -237,3 +239,29 @@ cpdef filterArrays(float[:,::1] L, float[::1] f, unsigned char[::1] mask):
                 L[c,i] = L[s,i] # Genotype likelihoods
             f[c] = f[s] # Allele frequency
             c += 1
+
+
+
+
+# Eric is going to try to put a little C-ish function here
+# for writing out the genotype posteriors
+cpdef writeBeagle(float[:,::1] Po, str beagle):
+    cdef int m = Po.shape[0]
+    cdef int n3 = Po.shape[1]
+    cdef int c = 0
+    cdef int i, s
+    #cdef FILE *outf
+    cdef FILE *pipe
+
+    #pipe = popen(str.encode("gzip - > " + beagle), "wb");
+    outf = fopen(str.encode(beagle), "wb")
+    for s in range(m):
+        for i in range(n3):
+            if i == 0:
+                fprintf(outf, "%1.4e", Po[s, i])
+            else:
+                fprintf(outf, "\t%1.4e", Po[s, i])
+            if i == n3-1:
+                fprintf(outf, "\n")
+    fclose(outf)
+

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -73,6 +73,7 @@ def emMAF(L, iter, tole, t):
 def callGeno(L, P, F, delta, t):
 	m, n = P.shape
 	G = np.zeros((m, n), dtype=np.int8)
+	
 	# Call genotypes with highest posterior probabilities
 	if F is None:
 		shared_cy.geno(L, P, G, delta, t)

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -74,25 +74,25 @@ def callGeno(L, P, F, delta, t):
 	m, n = P.shape
 	G = np.zeros((m, n), dtype=np.int8)
 	# Call genotypes with highest posterior probabilities
-  if F is None:
+	if F is None:
 		shared_cy.geno(L, P, G, delta, t)
-  else:
+	else:
 		shared_cy.genoInbreed(L, P, F, G, delta, t)
 
 
 ### Calculate genotype posteriors ###
 def calcPost(L, P, F, t):
-  m, n = P.shape
-  G = np.zeros((m, 3*n), dtype=np.float32) # in this function, G holds the genotype posteriors 
+	m, n = P.shape
+	G = np.zeros((m, 3*n), dtype=np.float32) # in this function, G holds the genotype posteriors 
 
-  # Call genotypes with highest posterior probabilities
-  # Calculate genotype posteriors
-  if F is None:
-    shared_cy.gpost(L, P, G, t)
-  else:
-    #shared_cy.genoInbreed(L, P, F, G, delta, t)
-    raise Exception("Calling posteriors with inbreeding not yet implemented.")
-  return G
+	# Call genotypes with highest posterior probabilities
+	# Calculate genotype posteriors
+	if F is None:
+		shared_cy.gpost(L, P, G, t)
+	else:
+		#shared_cy.genoInbreed(L, P, F, G, delta, t)
+		raise Exception("Calling posteriors with inbreeding not yet implemented.")
+	return G
 
 
 # Fake frequencies for educational purposes

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -73,7 +73,6 @@ def emMAF(L, iter, tole, t):
 def callGeno(L, P, F, delta, t):
 	m, n = P.shape
 	G = np.zeros((m, n), dtype=np.int8)
-	
 	# Call genotypes with highest posterior probabilities
 	if F is None:
 		shared_cy.geno(L, P, G, delta, t)

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -39,3 +39,18 @@ def callGeno(L, P, F, delta, t):
     else:
         shared_cy.genoInbreed(L, P, F, G, delta, t)
     return G
+
+
+### Genotype calling ###
+def calcPost(L, P, F, t):
+    m, n = P.shape
+    G = np.zeros((n, 3*n), dtype=dtype=np.float32) # in this function, G holds the genotype posteriors 
+
+    # Calculate genotype posteriors
+    if F is None:
+        shared_cy.gpost(L, P, G, t)
+    else:
+        #shared_cy.genoInbreed(L, P, F, G, delta, t)
+        raise Exception("Calling posteriors with inbreeding not yet implemented.")
+    return G
+

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -44,7 +44,7 @@ def callGeno(L, P, F, delta, t):
 ### Genotype calling ###
 def calcPost(L, P, F, t):
     m, n = P.shape
-    G = np.zeros((n, 3*n), dtype=dtype=np.float32) # in this function, G holds the genotype posteriors 
+    G = np.zeros((n, 3*m), dtype=np.float32) # in this function, G holds the genotype posteriors 
 
     # Calculate genotype posteriors
     if F is None:

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -44,7 +44,7 @@ def callGeno(L, P, F, delta, t):
 ### Genotype calling ###
 def calcPost(L, P, F, t):
     m, n = P.shape
-    G = np.zeros((n, 3*m), dtype=np.float32) # in this function, G holds the genotype posteriors 
+    G = np.zeros((m, 3*n), dtype=np.float32) # in this function, G holds the genotype posteriors 
 
     # Calculate genotype posteriors
     if F is None:

--- a/pcangsd/shared.py
+++ b/pcangsd/shared.py
@@ -73,19 +73,26 @@ def emMAF(L, iter, tole, t):
 def callGeno(L, P, F, delta, t):
 	m, n = P.shape
 	G = np.zeros((m, n), dtype=np.int8)
+	# Call genotypes with highest posterior probabilities
+  if F is None:
+		shared_cy.geno(L, P, G, delta, t)
+  else:
+		shared_cy.genoInbreed(L, P, F, G, delta, t)
 
 
-### Genotype calling ###
+### Calculate genotype posteriors ###
 def calcPost(L, P, F, t):
   m, n = P.shape
   G = np.zeros((m, 3*n), dtype=np.float32) # in this function, G holds the genotype posteriors 
 
   # Call genotypes with highest posterior probabilities
+  # Calculate genotype posteriors
   if F is None:
-		shared_cy.geno(L, P, G, delta, t)
+    shared_cy.gpost(L, P, G, t)
   else:
-		shared_cy.genoInbreed(L, P, F, G, delta, t)
-	 return G
+    #shared_cy.genoInbreed(L, P, F, G, delta, t)
+    raise Exception("Calling posteriors with inbreeding not yet implemented.")
+  return G
 
 
 # Fake frequencies for educational purposes

--- a/pcangsd/shared_cy.pyx
+++ b/pcangsd/shared_cy.pyx
@@ -197,7 +197,6 @@ cpdef void genoInbreed(float[:,::1] L, float[:,::1] P, double[::1] F, \
 			p2 = (1.0 - L[j,2*i+0] - L[j,2*i+1])*(P[j,i]*P[j,i] + \
 				P[j,i]*(1.0-P[j,i])*F[i])
 			pSum = p0 + p1 + p2
-			
 			# Call maximum posterior
 			if (p0 > p1) & (p0 > p2):
 				if (p0/pSum > delta):

--- a/pcangsd/shared_cy.pyx
+++ b/pcangsd/shared_cy.pyx
@@ -228,24 +228,25 @@ cpdef void freqs(float[:,::1] P, double[::1] f, int t) noexcept nogil:
 # Calculate genotype posteriors
 # Po is n rows by 3*n columns
 cpdef void gpost(float[:,::1] L, float[:,::1] P, float[:,::1] Po, int t):
-    cdef int m = P.shape[0]
-    cdef int n = P.shape[1]
-    cdef int i, s
-    cdef float p0, p1, p2, pSum
-    with nogil:
-        for s in prange(m, num_threads=t):
-            for i in range(n):
-                p0 = L[s,2*i+0]*(1 - P[s,i])*(1 - P[s,i])
-                p1 = L[s,2*i+1]*2*P[s,i]*(1 - P[s,i])
-                p2 = (1.0 - L[s,2*i+0] - L[s,2*i+1])*P[s,i]*P[s,i]
-                # deal with what seems to be the occasional negative value
-                if p0 < 0:
-                    p0 = 1e-10
-                if p1 < 0:
-                    p1 = 1e-10
-                if p2 < 0:
-                    p2 = 1e-10
-                pSum = p0 + p1 + p2
-                Po[s,3*i+0] = p0/pSum
-                Po[s,3*i+1] = p1/pSum
-                Po[s,3*i+2] = p2/pSum
+	cdef int m = P.shape[0]
+	cdef int n = P.shape[1]
+	cdef int i, s
+	cdef float p0, p1, p2, pSum
+	with nogil:
+		for s in prange(m, num_threads=t):
+			for i in range(n):
+				p0 = L[s,2*i+0]*(1 - P[s,i])*(1 - P[s,i])
+				p1 = L[s,2*i+1]*2*P[s,i]*(1 - P[s,i])
+				p2 = (1.0 - L[s,2*i+0] - L[s,2*i+1])*P[s,i]*P[s,i]
+				# deal with what seems to be the occasional negative value
+				if p0 < 0:
+					p0 = 1e-10
+				if p1 < 0:
+					p1 = 1e-10
+				if p2 < 0:
+					p2 = 1e-10
+				pSum = p0 + p1 + p2
+				Po[s,3*i+0] = p0/pSum
+				Po[s,3*i+1] = p1/pSum
+				Po[s,3*i+2] = p2/pSum
+

--- a/pcangsd/shared_cy.pyx
+++ b/pcangsd/shared_cy.pyx
@@ -183,6 +183,6 @@ cpdef gpost(float[:,::1] L, float[:,::1] P, float[:,::1] Po, int t):
                 if p2 < 0:
                     p2 = 1e-10
                 pSum = p0 + p1 + p2
-                Po[i,3*s+0] = p0/pSum
-                Po[i,3*s+1] = p1/pSum
-                Po[i,3*s+2] = p2/pSum
+                Po[s,3*i+0] = p0/pSum
+                Po[s,3*i+1] = p1/pSum
+                Po[s,3*i+2] = p2/pSum

--- a/pcangsd/shared_cy.pyx
+++ b/pcangsd/shared_cy.pyx
@@ -175,7 +175,14 @@ cpdef gpost(float[:,::1] L, float[:,::1] P, float[:,::1] Po, int t):
                 p0 = L[s,2*i+0]*(1 - P[s,i])*(1 - P[s,i])
                 p1 = L[s,2*i+1]*2*P[s,i]*(1 - P[s,i])
                 p2 = (1.0 - L[s,2*i+0] - L[s,2*i+1])*P[s,i]*P[s,i]
+                # deal with what seems to be the occasional negative value
+                if p0 < 0:
+                    p0 = 1e-10
+                if p1 < 0:
+                    p1 = 1e-10
+                if p2 < 0:
+                    p2 = 1e-10
                 pSum = p0 + p1 + p2
-                Po[i,3*i+0] = p0/pSum
-                Po[i,3*i+1] = p1/pSum
-                Po[i,3*i+2] = p2/pSum
+                Po[i,3*s+0] = p0/pSum
+                Po[i,3*s+1] = p1/pSum
+                Po[i,3*s+2] = p2/pSum

--- a/pcangsd/shared_cy.pyx
+++ b/pcangsd/shared_cy.pyx
@@ -161,3 +161,21 @@ cpdef genoInbreed(float[:,::1] L, float[:,::1] P, float[::1] F, \
                         G[s,i] = 2
                     else:
                         G[s,i] = -9
+
+# Calculate genotype posteriors
+# Po is n rows by 3*n columns
+cpdef gpost(float[:,::1] L, float[:,::1] P, float[:,::1] Po, int t):
+    cdef int m = P.shape[0]
+    cdef int n = P.shape[1]
+    cdef int i, s
+    cdef float p0, p1, p2, pSum
+    with nogil:
+        for s in prange(m, num_threads=t):
+            for i in range(n):
+                p0 = L[s,2*i+0]*(1 - P[s,i])*(1 - P[s,i])
+                p1 = L[s,2*i+1]*2*P[s,i]*(1 - P[s,i])
+                p2 = (1.0 - L[s,2*i+0] - L[s,2*i+1])*P[s,i]*P[s,i]
+                pSum = p0 + p1 + p2
+                Po[i,3*i+0] = p0/pSum
+                Po[i,3*i+1] = p1/pSum
+                Po[i,3*i+2] = p2/pSum

--- a/pcangsd/shared_cy.pyx
+++ b/pcangsd/shared_cy.pyx
@@ -197,6 +197,7 @@ cpdef void genoInbreed(float[:,::1] L, float[:,::1] P, double[::1] F, \
 			p2 = (1.0 - L[j,2*i+0] - L[j,2*i+1])*(P[j,i]*P[j,i] + \
 				P[j,i]*(1.0-P[j,i])*F[i])
 			pSum = p0 + p1 + p2
+			
 			# Call maximum posterior
 			if (p0 > p1) & (p0 > p2):
 				if (p0/pSum > delta):


### PR DESCRIPTION
Hey Jonas,

I think we met in Seattle one summer in about 2015 or so at the SISG.  You were in MCMC for Genetics with me and Matthew Stephens.

I have a few proposed additions here that I have found helpful.  Feel free to pull them in if you think this might be helpful for others.  The changes provide an option `--geno_post_save` that saves a TSV file (like a beagle file) of the genotype posteriors for all the individuals.  This seemed easier than getting the output from `--pi_save` and then doing the calculations elsewhere with the original genotype likelihoods.  It looks like this might also is relevant to #93 (at least to the extent that users would be happy to put column headers and preamble columns onto the output file).

It seemed to me from reading Jørsboe and Albrechtsen 2022 that it was good to use posterior probabilities for angsd doAsso in structured populations (rather then genotype likelihoods and the assumption of common population allele frequencies).  So, this is how I implemented getting those posteriors in a mixed group of salmon I was doing some GWAS in.  

There might already be a way to get these easily.  If so, let me know---I didn't find anything a couple years ago when I implemented this.  If not, then feel free to pull this in after adding whatever you think would be good.  

Note that I haven't implemented anything for the inbreeding flavor of the PCA.

I hope you are doing well.

best regards,

eric
